### PR TITLE
Fix HTTP headers handling

### DIFF
--- a/prestodb/constants.py
+++ b/prestodb/constants.py
@@ -24,3 +24,12 @@ HTTP = 'http'
 HTTPS = 'https'
 
 URL_STATEMENT_PATH = '/v1/statement'
+
+HEADER_CATALOG = 'X-Presto-Catalog'
+HEADER_SCHEMA = 'X-Presto-Schema'
+HEADER_SOURCE = 'X-Presto-Source'
+HEADER_USER = 'X-Presto-User'
+
+HEADER_SESSION = 'X-Presto-Session'
+HEADER_SET_SESSION = 'X-Presto-Set-Session'
+HEADER_CLEAR_SESSION = 'X-Presto-Clear-Session'

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,30 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from prestodb.client import get_header_values, get_session_property_values
+from prestodb import constants
+
+
+def test_get_header_values():
+    headers = {
+        constants.HEADER_SET_SESSION: 'a, b',
+    }
+    values = get_header_values(headers, constants.HEADER_SET_SESSION)
+    assert values == ['a', 'b']
+
+
+def test_get_session_property_values():
+    headers = {
+        constants.HEADER_SET_SESSION: 'a=1, b=2',
+    }
+    values = get_session_property_values(headers, constants.HEADER_SET_SESSION)
+    assert values == [('a', '1'), ('b', '2')]


### PR DESCRIPTION
These changes ensures that session values and property are always passed into the HTTP headers of Presto queries. They introduce a `ClientSession` class and a `PrestoRequest.http_headers` property.