### PR TITLE
Add connection/read timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
 services:
   - docker
 install:
-  - pip install .
+  - pip install .[tests]
 script:
   - pytest -s tests/ integration_tests/

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For development purpose, pip can reference the code you are modifying in a
 *virtualenv*:
 
 ```
-$ pip install -e .
+$ pip install -e .[tests]
 ```
 
 That way, you do not need to run `pip install` again to make your changes

--- a/prestodb/constants.py
+++ b/prestodb/constants.py
@@ -19,6 +19,7 @@ DEFAULT_CATALOG = None  # type: Optional[Text]
 DEFAULT_SCHEMA = None  # type: Optional[Text]
 DEFAULT_AUTH = None  # type: Optional[Any]
 DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_REQUEST_TIMEOUT = 30.0  # type: float
 
 HTTP = 'http'
 HTTPS = 'https'

--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -112,6 +112,7 @@ class Cursor(object):
         http_scheme=constants.HTTP,
         auth=constants.DEFAULT_AUTH,
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
+        request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
     ):
         self._host = host
         self._port = port
@@ -124,6 +125,7 @@ class Cursor(object):
         self._http_scheme = http_scheme
         self._auth = auth
         self._max_attempts = max_attempts
+        self._request_timeout = request_timeout
 
         self.arraysize = 1
         self._rows = None
@@ -169,6 +171,7 @@ class Cursor(object):
             self._http_scheme,
             self._auth,
             self._max_attempts,
+            self._request_timeout,
         )
 
         self._query = prestodb.client.PrestoQuery(request, sql=operation)

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,9 @@ setup(
         'six==1.10.0',
         'typing==3.5.3.0',
     ],
-    tests_require=['pytest', 'pytest-runner'],
+    extras_require={'tests':[
+        'httpretty==0.8.14',
+        'pytest',
+        'pytest-runner',
+    ]}
 )


### PR DESCRIPTION
Allow connection and read timeout to be passed in both cursor and
PrestoRequest.

Resolves https://github.com/prestodb/presto-python-client/issues/12