### PR TITLE
Expose stacktrace to users

### DIFF
--- a/prestodb/exceptions.py
+++ b/prestodb/exceptions.py
@@ -62,6 +62,10 @@ class PrestoQueryError(Exception):
         return self._error['failureInfo']['type']
 
     @property
+    def failure_info(self):
+        return self._error['failureInfo']
+
+    @property
     def message(self):
         return self._error.get(
             'message',


### PR DESCRIPTION
Error message with a complete stacktrace is necessary. This can include
the root stacktrace and all suppressed stacktraces in a recursive way.
Expose the entire failureInfo.