### PR TITLE
Add imports for Python2.7 compatibility

### DIFF
--- a/integration_tests/fixtures.py
+++ b/integration_tests/fixtures.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from contextlib import closing
 import logging

--- a/integration_tests/test_dbapi.py
+++ b/integration_tests/test_dbapi.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import fixtures
 from fixtures import run_presto

--- a/prestodb/__init__.py
+++ b/prestodb/__init__.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from . import dbapi
 from . import client

--- a/prestodb/auth.py
+++ b/prestodb/auth.py
@@ -1,7 +1,17 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import abc
 import os

--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -32,6 +32,9 @@ The main interface is :class:`PrestoQuery`: ::
     >> query =  PrestoQuery(request, sql)
     >> rows = list(query.execute())
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import logging
 import os

--- a/prestodb/constants.py
+++ b/prestodb/constants.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from typing import Any, Optional, Text  # NOQA: mypy types
 

--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -17,6 +17,10 @@ https://www.python.org/dev/peps/pep-0249/ .
 Fetch methods returns rows as a list of lists on purpose to let the caller
 decide to convert then to a list of tuples.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from future.standard_library import install_aliases
 install_aliases()
 import logging

--- a/prestodb/exceptions.py
+++ b/prestodb/exceptions.py
@@ -18,7 +18,6 @@ defined in pep-0249.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import functools
 import logging

--- a/prestodb/redirect.py
+++ b/prestodb/redirect.py
@@ -1,3 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import abc
 from future.standard_library import install_aliases
 install_aliases()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import httpretty
 import pytest

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,8 +18,6 @@ defined in pep-0249.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
-
 
 from prestodb import exceptions
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py27,py35,py3.6,pypy2
 
 [testenv]
-deps=pytest
+deps = pytest
+       httpretty
 commands = pytest -s tests/ integration_tests/


### PR DESCRIPTION
Add import to ensure compatibility on Python 2.7. Was triggered by an issue importing `prestodb.logging` module (added in another branch) that has the same name as the standard library `logging`. 