### PR TITLE
Add logging module

### DIFF
--- a/integration_tests/fixtures.py
+++ b/integration_tests/fixtures.py
@@ -14,7 +14,6 @@ from __future__ import division
 from __future__ import print_function
 
 from contextlib import closing
-import logging
 import os
 import requests
 import socket
@@ -28,9 +27,10 @@ import pytest
 
 from prestodb.client import PrestoQuery, PrestoRequest
 from prestodb.constants import DEFAULT_PORT
+import prestodb.logging
 
 
-logger = logging.getLogger(__name__)
+logger = prestodb.logging.get_logger(__name__)
 
 
 def get_latest_release():

--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -36,7 +36,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import os
 from requests_kerberos.exceptions import KerberosExchangeError
 from typing import Any, Dict, List, Optional, Text, Tuple, Union  # NOQA for mypy types
@@ -45,14 +44,14 @@ import requests
 
 from prestodb import constants
 from prestodb import exceptions
+import prestodb.logging
 import prestodb.redirect
 
 
 __all__ = ['PrestoQuery', 'PrestoRequest']
 
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = prestodb.logging.get_logger(__name__)
 
 
 MAX_ATTEMPTS = constants.DEFAULT_MAX_ATTEMPTS

--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -23,13 +23,13 @@ from __future__ import print_function
 
 from future.standard_library import install_aliases
 install_aliases()
-import logging
 
 from typing import Any, List, Optional  # NOQA for mypy types
 
 from prestodb import constants
 import prestodb.exceptions
 import prestodb.client
+import prestodb.logging
 import prestodb.redirect
 
 
@@ -39,7 +39,7 @@ __all__ = ['connect', 'Connection', 'Cursor']
 apilevel = '2.0'
 threadsafety = 2
 
-logger = logging.getLogger(__name__)
+logger = prestodb.logging.get_logger(__name__)
 
 
 class Error(Exception):

--- a/prestodb/exceptions.py
+++ b/prestodb/exceptions.py
@@ -20,12 +20,12 @@ from __future__ import division
 from __future__ import print_function
 
 import functools
-import logging
 import random
 import time
 
+import prestodb.logging
 
-logger = logging.getLogger(__name__)
+logger = prestodb.logging.get_logger(__name__)
 
 
 class HttpError(Exception):

--- a/prestodb/logging.py
+++ b/prestodb/logging.py
@@ -13,9 +13,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from . import dbapi
-from . import client
-from . import constants
-from . import logging
+import logging
 
-__version__ = '0.3.0'
+LEVEL = logging.INFO
+
+
+# TODO: provide interface to use ``logging.dictConfig``
+def get_logger(name, log_level=LEVEL):
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+    return logger


### PR DESCRIPTION
Add a `prestodb.logging` module to group definition and behavior of logging. One example is setting the same logging level to `INFO` in all *prestodb* sub-modules.