### PR TITLE
Ensure the client pulls results from the coordinator on COMMIT and ROLLBACK

### DIFF
--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -156,13 +156,13 @@ class Connection(object):
         return self._transaction
 
     def commit(self):
-        if not self.isolation_level:
+        if self.transaction is None:
             return
         self._transaction.commit()
         self._transaction = None
 
     def rollback(self):
-        if not self.isolation_level:
+        if self.transaction is None:
             raise RuntimeError('no transaction was started')
         self._transaction.rollback()
         self._transaction = None


### PR DESCRIPTION
Fix #45 

Rather than duplicating the code in `transaction.py`, `commit()` and `rollback()` use `prestodb.client.PrestoQuery` to execute the query. It ensures that the client pulls result until there is nothing more to pull.