### PR TITLE
Add missing DatabaseError definition

### DIFF
--- a/prestodb/exceptions.py
+++ b/prestodb/exceptions.py
@@ -39,7 +39,9 @@ class Http503Error(HttpError):
 class PrestoError(Exception):
     pass
 
-
+class DatabaseError(Exception):
+    pass
+        
 class PrestoQueryError(Exception):
     def __init__(self, error):
         self._error = error

--- a/prestodb/transaction.py
+++ b/prestodb/transaction.py
@@ -95,7 +95,7 @@ class Transaction(object):
         try:
             list(query.execute())
         except Exception as err:
-            raise prestodb.exceptions.DatabaseErrror(
+            raise prestodb.exceptions.DatabaseError(
                 'failed to commit transaction {}: {}'.format(self._id, err))
 
     def rollback(self):
@@ -104,5 +104,5 @@ class Transaction(object):
         try:
             list(query.execute())
         except Exception as err:
-            raise prestodb.exceptions.DatabaseErrror(
+            raise prestodb.exceptions.DatabaseError(
                 'failed to rollback transaction {}: {}'.format(self._id, err))


### PR DESCRIPTION
There is a bug in transaction.py. No DatabaseErrror definition in exception.py. I fix it