### PR TITLE
Support cookies in transactions

### DIFF
--- a/integration_tests/test_dbapi.py
+++ b/integration_tests/test_dbapi.py
@@ -65,11 +65,13 @@ def test_select_query(presto_connection):
 
 
 def test_select_query_result_iteration(presto_connection):
-    cur = presto_connection.cursor()
-    cur.execute('select custkey from tpch.sf1.customer LIMIT 10')
-    rows0 = cur.genall()
-    cur.execute('select custkey from tpch.sf1.customer LIMIT 10')
-    rows1 = cur.fetchall()
+    cur0 = presto_connection.cursor()
+    cur0.execute('select custkey from tpch.sf1.customer LIMIT 10')
+    rows0 = cur0.genall()
+
+    cur1 = presto_connection.cursor()
+    cur1.execute('select custkey from tpch.sf1.customer LIMIT 10')
+    rows1 = cur1.fetchall()
 
     assert len(list(rows0)) == len(rows1)
 
@@ -177,7 +179,7 @@ def test_transaction_single(presto_connection_with_transaction):
 
 def test_transaction_rollback(presto_connection_with_transaction):
     connection = presto_connection_with_transaction
-    for i in range(3):
+    for _ in range(3):
         cur = connection.cursor()
         cur.execute('SELECT * FROM tpch.sf1.customer LIMIT 1000')
         rows = cur.fetchall()

--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -203,6 +203,7 @@ class PrestoRequest(object):
         catalog=None,  # type: Text
         schema=None,  # type: Text
         session_properties=None,  # type: Optional[Dict[Text, Any]]
+        http_session=None,  # type: Any
         http_headers=None,  # type: Optional[Dict[Text, Text]]
         transaction_id=NO_TRANSACTION,  # type: Optional[Text]
         http_scheme=constants.HTTP,  # type: Text
@@ -226,8 +227,12 @@ class PrestoRequest(object):
         self._host = host
         self._port = port
         self._next_uri = None  # type: Optional[Text]
-        # mypy cannot follow module import
-        self._http_session = self.http.Session()  # type: ignore
+
+        if http_session is not None:
+            self._http_session = http_session
+        else:
+            # mypy cannot follow module import
+            self._http_session = self.http.Session()  # type: ignore
         self._http_session.headers.update(self.http_headers)
         self._auth = auth
         if self._auth:
@@ -413,9 +418,9 @@ class PrestoRequest(object):
 
         if constants.HEADER_SET_SESSION in http_response.headers:
             for key, value in get_session_property_values(
-                    response.headers,
-                    constants.HEADER_SET_SESSION,
-                ):
+                response.headers,
+                constants.HEADER_SET_SESSION,
+            ):
                 self._client_session.properties[key] = value
 
         self._next_uri = response.get('nextUri')


### PR DESCRIPTION
Use same `PrestoRequest` instance to execute queries within the same transaction.

When an HTTP gateway is used to balance queries across multiple Presto
coordinators, queries within the same transaction must go to the same
coordinator. An HTTP cookie can support this behavior such as `Set-Cookie:
Presto-Gateway-Sticky={host}:{port};Version=1`. The cookie is persisted by the
`requests.Session` object referenced by `PrestoRequest._http_session`. Hence
All queries should be sent with the same session data.

The behavior introduced by  30c1735 was not working because the `Presto-Gateway-Sticky` cookie was not in the `Response` object. It was already persisted in the `requests.Session` object.

I manually tested the execution of queries within the same transaction and will add an integration tests that will require a Presto HTTP gateway:

```python
 with prestodb.dbapi.Connection(host=gateway_host, port=7778, user='ggreg', source='tests', catalog=catalog, schema=schema, http_scheme='https', isolation_level=prestodb.transaction.READ_COMMITTED, auth=auth) as conn:
    cur = conn.cursor()
    list(cur.execute('SELECT 1'))
    print(cur._query._stats['queryId'])
    list(cur.execute('SELECT 2'))
    print(cur._query._stats['queryId'])
    sleep(10)
    list(cur.execute('SELECT 3'))
    print(cur._query._stats['queryId'])
    sleep(60)
    list(cur.execute('SELECT 4'))
    print(cur._query._stats['queryId'])
    sleep(300)
    list(cur.execute('SELECT 5'))
    print(cur._query._stats['queryId'])
```