### PR TITLE
Use lighter weight six for python3 compatibility

### DIFF
--- a/prestodb/auth.py
+++ b/prestodb/auth.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import abc
 import os
 
-from future.utils import with_metaclass
+from six import with_metaclass
 from typing import Any, Optional, Text  # NOQA
 
 import requests_kerberos

--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -21,9 +21,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from future.standard_library import install_aliases
-install_aliases()
-
 from typing import Any, List, Optional  # NOQA for mypy types
 
 from prestodb import constants

--- a/prestodb/redirect.py
+++ b/prestodb/redirect.py
@@ -14,14 +14,12 @@ from __future__ import division
 from __future__ import print_function
 
 import abc
-from future.standard_library import install_aliases
-install_aliases()
 
-from future.utils import with_metaclass
+from six import with_metaclass
 import ipaddress
 import socket
 from typing import Any, Text  # NOQA
-from urllib.parse import urlparse
+from six.moves.urllib_parse import urlparse
 
 
 class RedirectHandler(with_metaclass(abc.ABCMeta)):  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -57,16 +57,16 @@ setup(
     ],
     install_requires=[
         'click',
-        'future',
-        'ipaddress',
         'requests',
         'requests_kerberos',
         'six',
-        'typing',
     ],
-    extras_require={'tests':[
-        'httpretty',
-        'pytest',
-        'pytest-runner',
-    ]}
+    extras_require={
+        'tests':[
+            'httpretty',
+            'pytest',
+            'pytest-runner',
+        ],
+        ':python_version=="2.7"': ['ipaddress', 'typing'],
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py3.6,pypy2
+envlist = py27,py35,py36,pypy2
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
We're seeing issues of `python-future`'s types leaking out of the presto
client and causing bad interactions with other libraries.  `future` wasn't
actually being used for all that much and was easily replaced with (already
used) `six`.

Additionally, I made `typing` and `ipaddress` only install in python2.x, they
are already standard library modules in the other supported python versions.