### PR TITLE
Fix SET SESSION support by using http_response.headers

### DIFF
--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -411,14 +411,14 @@ class PrestoRequest(object):
 
         if constants.HEADER_CLEAR_SESSION in http_response.headers:
             for prop in get_header_values(
-                response.headers,
+                http_response.headers,
                 constants.HEADER_CLEAR_SESSION,
             ):
                 self._client_session.properties.pop(prop, None)
 
         if constants.HEADER_SET_SESSION in http_response.headers:
             for key, value in get_session_property_values(
-                response.headers,
+                http_response.headers,
                 constants.HEADER_SET_SESSION,
             ):
                 self._client_session.properties[key] = value


### PR DESCRIPTION
Otherwise, running `SET SESSION` fails with:
```
AttributeError: 'dict' object has no attribute 'headers'

  .../lib/python2.7/site-packages/prestodb/dbapi.py, line 306:
            return list(self.genall())
  .../lib/python2.7/site-packages/prestodb/client.py, line 465:
                rows = self._query.fetch()
  .../lib/python2.7/site-packages/prestodb/client.py, line 532:
            status = self._request.process(response)
  .../lib/python2.7/site-packages/prestodb/client.py, line 421:
                    response.headers,
```