### PR TITLE
Add support for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ rows for example `Cursorfetchone()` or `Cursor.fetchmany()`. By default
 `Cursor.fetchmany()` fetches one row. Please set
 `prestodb.dbapi.Cursor.arraysize` accordingly.
 
+# Basic Authentication
+The `BasicAuthentication` class can be used to connect to a LDAP-configured Presto
+cluster:
+```python
+import prestodb
+conn=prestodb.dbapi.connect(
+    host='coordinator url',
+    port=8443,
+    user='the-user',
+    catalog='the-catalog',
+    schema='the-schema',
+    http_scheme='https',
+    auth=prestodb.auth.BasicAuthentication("principal id", "password"),
+)
+cur = conn.cursor()
+cur.execute('SELECT * FROM system.runtime.nodes')
+rows = cur.fetchall()
+```
+
 # Transactions
 The client runs by default in *autocommit* mode. To enable transactions, set
 *isolation_level* to a value different than `IsolationLevel.AUTOCOMMIT`:

--- a/prestodb/auth.py
+++ b/prestodb/auth.py
@@ -102,3 +102,34 @@ class KerberosAuthentication(Authentication):
 
     def handle_error(self, handle_error):
         pass
+
+
+class BasicAuthentication(Authentication):
+    def __init__(self, username, password):
+        self._username = username
+        self._password = password
+
+    def set_client_session(self, client_session):
+        pass
+
+    def set_http_session(self, http_session):
+        try:
+            import requests.auth
+        except ImportError:
+            raise RuntimeError('unable to import requests.auth')
+
+        http_session.auth = requests.auth.HTTPBasicAuth(
+            self._username,
+            self._password
+        )
+        return http_session
+
+    def setup(self, presto_client):
+        self.set_client_session(presto_client.client_session)
+        self.set_http_session(presto_client.http_session)
+
+    def get_exceptions(self):
+        return ()
+
+    def handle_error(self, handle_error):
+        pass


### PR DESCRIPTION
#44 
I've done an end-to-end test for this implementation. It was tested against a Presto cluster with LDAP authentication. On the client side, the commit was applied by running `pip install -e .[tests]` in a virtual environment created by `virtualenv`. And the following script worked fine:
```
import prestodb

conn=prestodb.dbapi.connect(
    host='coordinator url',
    port=8443,
    user='user id',
    catalog='hive',
    http_scheme='https',
    auth=prestodb.auth.BasicAuthentication("principal id", "password"),
)
cur = conn.cursor()
cur.execute("show schemas'")
rows = cur.fetchall()
for row in rows:
    print row
```