### PR TITLE
Add support for Presto warnings

### DIFF
--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -219,6 +219,12 @@ class Cursor(object):
             return self._query.stats
         return None
 
+    @property
+    def warnings(self):
+        if self._query is not None:
+            return self._query.warnings
+        return None
+
     def setinputsizes(self, sizes):
         raise prestodb.exceptions.NotSupportedError
 


### PR DESCRIPTION
Expose Presto warnings in the client. Warnings are optional and represented as a list.