### PR TITLE
the argument for isolation_level when using a context manager for tra…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ The client runs by default in *autocommit* mode. To enable transactions, set
 
 ```python
 import prestodb
+from prestodb import transaction
 with prestodb.dbapi.connect(
     host='localhost',
     port=8080,
     user='the-user',
     catalog='the-catalog',
     schema='the-schema',
-    isolation_level='transaction.IsolationLevel.REPEATABLE_READ',
+    isolation_level=transaction.IsolationLevel.REPEATABLE_READ,
 ) as conn:
   cur = conn.cursor()
   cur.execute('INSERT INTO sometable VALUES (1, 2, 3)')

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ with prestodb.dbapi.connect(
     user='the-user',
     catalog='the-catalog',
     schema='the-schema',
-    isolation_level=transaction.IsolationLevel.REPEATABLE_READ,
+    isolation_level='transaction.IsolationLevel.REPEATABLE_READ',
 ) as conn:
   cur = conn.cursor()
   cur.execute('INSERT INTO sometable VALUES (1, 2, 3)')


### PR DESCRIPTION
…nsactions is a string, not a reference to the python package 'transaction'

Hello - I noticed a small typo while using prestodb within a context manager - it's a small change, but may save someone else some trouble.