### PR TITLE
Fixed default http_scheme in Connection class from 'http' to 'https'

### DIFF
--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -69,7 +69,7 @@ class Connection(object):
         schema=constants.DEFAULT_SCHEMA,
         session_properties=None,
         http_headers=None,
-        http_scheme=constants.HTTP,
+        http_scheme=constants.HTTPS,
         auth=constants.DEFAULT_AUTH,
         redirect_handler=prestodb.redirect.GatewayRedirectHandler(),
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,


### PR DESCRIPTION
Http scheme is not supported and raises a ValueError. Yet it is the default value that is set in Connection constructor. We should either make https the default (as in this pull request), or at least add a `http_scheme='https'` argument to dbapi.connect method in the quick start section of the readme.