### PR TITLE
Add support for Oauth to enable GCS access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "pypy-5.4"
+  - "3.7"
+  - "pypy3.6-7.0.0"
 env:
   - PRESTO_VERSION=0.202
 services:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Introduction
 
 This package provides a client interface to query [Presto](https://prestodb.io/)
-a distributed SQL engine. It supports Python 2.7, 3.5, 3.6, and pypy.
+a distributed SQL engine. It supports Python 2.7, 3.5, 3.6, 3.7, and pypy.
 
 # Installation
 
@@ -54,6 +54,36 @@ conn=prestodb.dbapi.connect(
 cur = conn.cursor()
 cur.execute('SELECT * FROM system.runtime.nodes')
 rows = cur.fetchall()
+```
+
+# Oauth Authentication
+To enable GCS access, Oauth authentication support is added by passing in a `shadow.json` file of a service account.
+Following example shows a use case where both Kerberos and Oauth authentication are enabled.
+
+```python
+import getpass
+import prestodb
+from prestodb.client import PrestoRequest, PrestoQuery
+from requests_kerberos import DISABLED
+
+kerberos_auth = prestodb.auth.KerberosAuthentication(
+   mutual_authentication=DISABLED,
+   service_name='kerberos service name',
+   force_preemptive=True,
+   hostname_override='example.com'
+)
+
+req = PrestoRequest(
+    host='GCP coordinator url',
+    port=443,
+    user=getpass.getuser(),
+    service_account_file='Service account json file path',
+    http_scheme='https',
+    auth=kerberos_auth
+)
+
+query = PrestoQuery(req, "SELECT * FROM system.runtime.nodes")
+rows = list(query.execute())
 ```
 
 # Transactions

--- a/prestodb/constants.py
+++ b/prestodb/constants.py
@@ -41,3 +41,8 @@ HEADER_CLEAR_SESSION = HEADER_PREFIX + "Clear-Session"
 
 HEADER_STARTED_TRANSACTION = HEADER_PREFIX + "Started-Transaction-Id"
 HEADER_TRANSACTION = HEADER_PREFIX + "Transaction-Id"
+
+PRESTO_EXTRA_CREDENTIAL = "X-Presto-Extra-Credential"
+GCS_CREDENTIALS_OAUTH_TOKEN_KEY = "hive.gcs.oauth"
+
+GCS_READ_ONLY = "https://www.googleapis.com/auth/devstorage.read_only"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ with open("prestodb/__init__.py", "rb") as f:
 
 kerberos_require = ["requests_kerberos"]
 
-all_require = [kerberos_require]
+google_auth_require = ["google_auth"]
+
+all_require = [kerberos_require, google_auth_require]
 
 tests_require = all_require + ["httpretty", "pytest", "pytest-runner"]
 
@@ -70,6 +72,7 @@ setup(
     extras_require={
         "all": all_require,
         "kerberos": kerberos_require,
+        "google_auth": google_auth_require,
         "tests": tests_require,
         ':python_version=="2.7"': py27_require,
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,pypy2
+envlist = py27,py35,py36,py37,pypy2
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
This PR adds Oauth support to enable GCS access by:
- Passing in service account file `shadow.json` to obtain credentials inside `PrestoRequest`
- Using Scope value of https://www.googleapis.com/auth/devstorage.read_only internally

Auto refresh: credential is refreshed if it fails on validity checking each time a query is executed.