### PR TITLE
Performance improvements: Check log level. Allow non-default json lib.

### DIFF
--- a/prestodb/__init__.py
+++ b/prestodb/__init__.py
@@ -20,4 +20,4 @@ from . import constants
 from . import exceptions
 from . import logging
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -210,6 +210,7 @@ class PrestoRequest(object):
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,  # type: Union[float, Tuple[float, float]]
         handle_retry=exceptions.RetryWithExponentialBackoff(),
         service_account_file=None,
+        json_lib=None,
     ):
         # type: (...) -> None
         self._client_session = ClientSession(
@@ -258,6 +259,7 @@ class PrestoRequest(object):
         self._handle_retry = handle_retry
         self.max_attempts = max_attempts
         self._http_scheme = http_scheme
+        self.json_lib = json_lib
 
     @property
     def transaction_id(self):
@@ -355,6 +357,8 @@ class PrestoRequest(object):
             while http_response is not None and http_response.is_redirect:
                 location = http_response.headers["Location"]
                 url = self._redirect_handler.handle(location)
+                log_level = logger.getEffectiveLevel()
+                if log_level <= logging.logging.INFO:
                 logger.info(
                     "redirect {} from {} to {}".format(
                         http_response.status_code, location, url
@@ -406,9 +410,14 @@ class PrestoRequest(object):
         if not http_response.ok:
             self.raise_response_error(http_response)
 
+        log_level = logger.getEffectiveLevel()
         http_response.encoding = "utf-8"
-        response = http_response.json()
-        logger.debug("HTTP {}: {}".format(http_response.status_code, response))
+        if self.json_lib:
+            response = self.json_lib.loads(http_response.content)
+        else:
+            response = http_response.json()
+        if log_level <= logging.logging.DEBUG:
+            logger.debug("HTTP {}: {}".format(http_response.status_code, response))
         if "error" in response:
             raise self._process_error(response["error"], response.get("id"))
 
@@ -474,11 +483,13 @@ class PrestoResult(object):
         self._rows = None
 
         # Subsequent fetches from GET requests until next_uri is empty.
+        log_level = logger.getEffectiveLevel()
         while not self._query.is_finished():
             rows = self._query.fetch()
             for row in rows:
                 self._rownumber += 1
-                logger.debug("row {}".format(row))
+                if log_level <= logging.logging.DEBUG:
+                    logger.debug("row {}".format(row))
                 yield row
 
 
@@ -554,7 +565,9 @@ class PrestoQuery(object):
         if status.columns:
             self._columns = status.columns
         self._stats.update(status.stats)
-        logger.debug(status)
+        log_level = logger.getEffectiveLevel()
+        if log_level <= logging.logging.DEBUG:
+            logger.debug(status)
         if status.next_uri is None:
             self._finished = True
         return status.rows
@@ -565,13 +578,17 @@ class PrestoQuery(object):
         if self.query_id is None or self.is_finished():
             return
 
+        log_level = logger.getEffectiveLevel()
         self._cancelled = True
         url = self._request.get_url("/v1/query/{}".format(self.query_id))
-        logger.debug("cancelling query: %s", self.query_id)
+        if log_level <= logging.logging.DEBUG:
+            logger.debug("cancelling query: %s", self.query_id)
         response = self._request.delete(url)
-        logger.info(response)
+        if log_level <= logging.logging.INFO:
+            logger.info(response)
         if response.status_code == requests.codes.no_content:
-            logger.debug("query cancelled: %s", self.query_id)
+            if log_level <= logging.logging.DEBUG:
+                logger.debug("query cancelled: %s", self.query_id)
             return
         self._request.raise_response_error(response)
 

--- a/prestodb/dbapi.py
+++ b/prestodb/dbapi.py
@@ -75,6 +75,7 @@ class Connection(object):
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
         isolation_level=IsolationLevel.AUTOCOMMIT,
+        json_lib=None,
     ):
         self.host = host
         self.port = port
@@ -95,6 +96,7 @@ class Connection(object):
         self._isolation_level = isolation_level
         self._request = None
         self._transaction = None
+        self._json_lib = json_lib
 
     @property
     def isolation_level(self):
@@ -154,6 +156,9 @@ class Connection(object):
             self.redirect_handler,
             self.max_attempts,
             self.request_timeout,
+            None,
+            None,
+            self._json_lib,
         )
 
     def cursor(self):


### PR DESCRIPTION
- Check the log level and prevent unnecessary calls to `logger`. In testing this resulted in a 15% decrease in query time.
- Allow user to pass in a different json library. Using `ujson` instead of the json library built in to `requests`, combined with the above change, resulted in a 24% decrease in query time.
