### PR TITLE
Remove debug log to avoid leaking sensitive information in production

### DIFF
--- a/prestodb/client.py
+++ b/prestodb/client.py
@@ -482,7 +482,6 @@ class PrestoResult(object):
             rows = self._query.fetch()
             for row in rows:
                 self._rownumber += 1
-                logger.debug("row {}".format(row))
                 yield row
 
 


### PR DESCRIPTION
* Having a default debug log to print out the row level information would create the risk of printing the sensitive information in the production environment. 