### PR TITLE
Change Presto client to support intergration with SQLAlchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Following example shows a use case where both Kerberos and Oauth authentication 
 ```python
 import getpass
 import prestodb
-from prestodb.client import PrestoRequest, PrestoQuery
+from prestodb.client import ClientSession, PrestoRequest, PrestoQuery
 from requests_kerberos import DISABLED
 
 kerberos_auth = prestodb.auth.KerberosAuthentication(
@@ -76,7 +76,7 @@ kerberos_auth = prestodb.auth.KerberosAuthentication(
 req = PrestoRequest(
     host='GCP coordinator url',
     port=443,
-    user=getpass.getuser(),
+    client_session=ClientSession(user=getpass.getuser()),
     service_account_file='Service account json file path',
     http_scheme='https',
     auth=kerberos_auth

--- a/integration_tests/fixtures.py
+++ b/integration_tests/fixtures.py
@@ -23,7 +23,7 @@ import click
 import logging
 import pytest
 import requests
-from prestodb.client import PrestoQuery, PrestoRequest
+from prestodb.client import ClientSession, PrestoQuery, PrestoRequest
 from prestodb.constants import DEFAULT_PORT
 from prestodb.exceptions import TimeoutError
 
@@ -110,7 +110,7 @@ def start_presto(image_tag=None, build=True, with_cache=True):
 
 
 def wait_for_presto_workers(host, port, timeout=30):
-    request = PrestoRequest(host=host, port=port, user="test_fixture")
+    request = PrestoRequest(host=host, port=port, client_session=ClientSession(user="test_fixture"))
     sql = "SELECT state FROM system.runtime.nodes"
     t0 = time.time()
     while True:

--- a/integration_tests/test_dbapi.py
+++ b/integration_tests/test_dbapi.py
@@ -11,9 +11,12 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 
-import integration_tests.fixtures as fixtures
+from datetime import date, datetime
+import numpy as np
 import prestodb
 import pytest
+
+import integration_tests.fixtures as fixtures
 from integration_tests.fixtures import run_presto
 from prestodb.transaction import IsolationLevel
 
@@ -116,7 +119,64 @@ def test_select_failed_query(presto_connection):
         cur.execute("select * from catalog.schema.do_not_exist")
         cur.fetchall()
 
+def test_select_query_result_iteration_statement_params(presto_connection):
+    cur = presto_connection.cursor()
+    cur.execute(
+        """
+        select * from (
+            values
+            (1, 'one', 'a'),
+            (2, 'two', 'b'),
+            (3, 'three', 'c'),
+            (4, 'four', 'd'),
+            (5, 'five', 'e')
+        ) x (id, name, letter)
+        where id >= ?
+        """,
+        params=(3,)  # expecting all the rows with id >= 3
+    )
 
+    rows = cur.fetchall()
+    assert len(rows) == 3
+
+    for row in rows:
+        # Validate that all the ids of the returned rows are greather or equals than 3
+        assert row[0] >= 3
+
+
+def test_select_query_param_types(presto_connection):
+    cur = presto_connection.cursor()
+
+    date_param = date.today()
+    timestamp_param = datetime.now().replace(microsecond=0)
+    float_param = 1.5
+    list_param = (1,2,3)
+    cur.execute(
+        """
+        select ?,?,?,?
+        """,
+        params=(date_param, timestamp_param, float_param, list_param,)
+    )
+
+    rows = cur.fetchall()
+    assert len(rows) == 1
+    for row in rows:
+        assert date.fromisoformat(row[0]) == date_param
+        assert datetime.strptime(row[1], "%Y-%m-%d %H:%M:%S.%f") == timestamp_param
+        assert row[2] == float_param
+        assert (row[3] == np.array(list_param)).all()
+
+@pytest.mark.parametrize('params', [
+    'NOT A LIST OR TUPPLE',
+    {'invalid', 'params'},
+    object,
+])
+def test_select_query_invalid_params(presto_connection, params):
+    cur = presto_connection.cursor()
+    with pytest.raises(AssertionError):
+        cur.execute('select ?', params=params)
+
+        
 def test_select_tpch_1000(presto_connection):
     cur = presto_connection.cursor()
     cur.execute("SELECT * FROM tpch.sf1.customer LIMIT 1000")

--- a/prestodb/constants.py
+++ b/prestodb/constants.py
@@ -42,6 +42,9 @@ HEADER_CLEAR_SESSION = HEADER_PREFIX + "Clear-Session"
 HEADER_STARTED_TRANSACTION = HEADER_PREFIX + "Started-Transaction-Id"
 HEADER_TRANSACTION = HEADER_PREFIX + "Transaction-Id"
 
+HEADER_PREPARED_STATEMENT = 'X-Presto-Prepared-Statement'
+HEADER_ADDED_PREPARE = 'X-Presto-Added-Prepare'
+
 PRESTO_EXTRA_CREDENTIAL = "X-Presto-Extra-Credential"
 GCS_CREDENTIALS_OAUTH_TOKEN_KEY = "hive.gcs.oauth"
 


### PR DESCRIPTION
Change Presto client to support integration with SQLAlchemy

This is a cherry-pick of the following two commits:

[Make ClientSession thread-safe]
cherry-pick of https://github.com/trinodb/trino-python-client/commit/79a4814a0f8054cf6596fc6cf25337464c6ea514
Co-authored by Michiel De Smet (mdesmet)

[Support parameterized statements in Presto Python Client]
Cherry-pick of https://github.com/trinodb/trino-python-client/commit/a7438556213bcf954f8a7a5063c7823bbb177edb

Co-authored by: Harrington Joseph (harph)
Testplan: pytest
```
collected 31 items

integration_tests/test_dbapi.py ...............                                                                                                                                                                                                           [ 48%]
tests/test_client.py ...........                                                                                                                                                                                                                          [ 83%]
tests/test_exceptions.py ...                                                                                                                                                                                                                              [ 93%]
tests/test_http.py ..                                                                                                                                                                                                                                     [100%]

======================================================================================================================= warnings summary ========================================================================================================================
tests/test_client.py::test_authentication_fail_retry
  /Users/lyublena/dev/presto-python-client/venv/lib/python3.8/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-4

  Traceback (most recent call last):
    File "/opt/facebook/nix/store/p4yr7ykc4mzzbsh489w9bysqcr0l0r8a-python3-3.8.9/lib/python3.8/threading.py", line 932, in _bootstrap_inner
      self.run()
    File "/opt/facebook/nix/store/p4yr7ykc4mzzbsh489w9bysqcr0l0r8a-python3-3.8.9/lib/python3.8/threading.py", line 870, in run
      self._target(*self._args, **self._kwargs)
    File "/Users/lyublena/dev/presto-python-client/venv/lib/python3.8/site-packages/httpretty/core.py", line 1133, in fill_filekind
      fk.write(utf8(item) + b'\n')
  ValueError: write to closed file

    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================ 31 passed, 1 warning in 30.46s =================================================================================================================

```
Above warning is independent of changes and exists on master too.