### PR TITLE
Remove resolving IP to DNS for nextURI

### DIFF
--- a/prestodb/redirect.py
+++ b/prestodb/redirect.py
@@ -9,16 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import abc
-
-from six import with_metaclass
 import ipaddress
 import socket
 from typing import Any, Text  # NOQA
+
+from six import with_metaclass
 from six.moves.urllib_parse import urlparse
 
 
@@ -28,22 +26,9 @@ class RedirectHandler(with_metaclass(abc.ABCMeta)):  # type: ignore
         pass
 
 
-def _normalize_url_with_hostname(url):
-    # type: (Text) -> Text
-    # TODO: replace urlparse by more robust utf-8 handling code
-    parsed = urlparse(url.encode("utf-8"))
-    hostname = parsed.hostname.decode("utf-8")  # type: ignore
-    try:
-        ipaddress.ip_address(hostname)
-        hostname = socket.gethostbyaddr(hostname)[0].encode("utf-8")
-    except ValueError:
-        return url
-    return parsed._replace(netloc=b"%s:%d" % (hostname, parsed.port)).geturl()
-
-
 class GatewayRedirectHandler(RedirectHandler):
     def handle(self, url):
         # type: (Text) -> Text
         if url is None:
             return None
-        return _normalize_url_with_hostname(url)
+        return url


### PR DESCRIPTION
Summary:
For some setups with different SSL configurations it is possible that SAN will not have hostname in it but only IP address. In this case rewrite nextURI to always use DNS name instead of IP breaks such setups.

It would be better to keep what server asks us to redirect rather than changing that URL.

Testing:
Before the change:
```
INFO:__main__:Executing query...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): <gateway hostname>:7778
DEBUG:urllib3.connectionpool:https://<gateway hostname>:7778 "POST /v1/statement HTTP/1.1" 307 0
INFO:__main__:[REDIRECT] _normalize_url_with_hostname:
  INPUT:  https://[IPv6]:7778/v1/statement?...
  OUTPUT: b'https://<hostname>:7778/v1/statement?...'
```

After the change:
```
INFO:__main__:Executing query...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): <gateway hostname>:7778
DEBUG:urllib3.connectionpool:https://<gateway hostname>:7778 "POST /v1/statement HTTP/1.1" 307 0
INFO:__main__:[REDIRECT] _normalize_url_with_hostname:
  INPUT:  https://[<IPv6>]:7778/v1/statement?...
  OUTPUT: b'https://[<IPv6>]:7778/v1/statement?...'
```